### PR TITLE
add wallet sample app

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -31,6 +31,10 @@ repositories:
 
   - type: github-release
     owner: digital-asset
+    repository: wallet-sample-app
+
+  - type: github-release
+    owner: digital-asset
     repository: dablchat
 
   - type: github-release


### PR DESCRIPTION
Adds the https://github.com/digital-asset/wallet-sample-app as an arcade repo repository.